### PR TITLE
Apparently there are some requests which doesnt have a response example

### DIFF
--- a/test/item/doc/parser/parser_test.exs
+++ b/test/item/doc/parser/parser_test.exs
@@ -24,8 +24,6 @@ defmodule TwitchApiScraper.Item.Doc.ParserTest do
       test "#{index} of #{length(@parsed_tree)}: checks doc item from the parsed tree Doc struct response is correct" do
         assert %Item{responses: %Response{responses: responses}} =
                  Parser.parse_doc_tree_item(unquote(parsed_item))
-
-        assert length(responses) != 0
       end
 
       test "#{index} of #{length(@parsed_tree)}: checks doc item from the parsed tree Doc struct request is correct" do


### PR DESCRIPTION
Seeing how the new HTML struct from twitch: https://dev.twitch.tv/docs/api/reference#update-user-chat-color we can appreciate that the response documentation example has been deleted from some requests.

This won't bind the testing to check every request has a doc response example. I thought there was needed some implementation change in the parser itself.